### PR TITLE
Remove instances of skills and interests

### DIFF
--- a/backend/src/models/userData.js
+++ b/backend/src/models/userData.js
@@ -25,10 +25,6 @@ const userDataSchema = new mongoose.Schema(
       zip_code: { type: String }
     },
     history: { type: String },
-    skills_interests: {
-      type: String
-      //list[] skills
-    },
     employment: {
       industry: { type: String },
       occupation: { type: [String] }

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -123,13 +123,6 @@ router.get('/', (req, res, next) => {
       res.status(400).json({ error: 'Invalid availability param' });
     }
   }
-  if (req.query.skills_interests) {
-    try {
-      filter.skills_interests = JSON.parse(req.query.skills_interests);
-    } catch (e) {
-      res.status(400).json({ error: 'Invalid skills_interests param' });
-    }
-  }
   if (req.query.lastPaginationId) {
     filter._id = { $lt: mongoose.Types.ObjectId(req.query.lastPaginationId) };
   }

--- a/backend/src/util/validators.js
+++ b/backend/src/util/validators.js
@@ -38,10 +38,6 @@ const USER_DATA_VALIDATOR = [
     .isAscii()
     .trim()
     .escape(),
-  check('skills_interests.languages')
-    .isAscii()
-    .trim()
-    .escape(),
   check('history.volunteer_interest_cause')
     .isAscii()
     .trim()
@@ -51,10 +47,6 @@ const USER_DATA_VALIDATOR = [
     .trim()
     .escape(),
   check('history.volunteer_commitment')
-    .isAscii()
-    .trim()
-    .escape(),
-  check('skills_interests.skills_qualifications')
     .isAscii()
     .trim()
     .escape(),
@@ -68,21 +60,6 @@ const USER_DATA_VALIDATOR = [
   check('availability.weekend_mornings').isBoolean(),
   check('availability.weekend_afternoons').isBoolean(),
   check('availability.weekend_evenings').isBoolean(),
-  check('skills_interests.admin_office').isBoolean(),
-  check('skills_interests.admin_virtual').isBoolean(),
-  check('skills_interests.atlanta_shelter').isBoolean(),
-  check('skills_interests.orlando_shelter').isBoolean(),
-  check('skills_interests.graphic_web_design').isBoolean(),
-  check('skills_interests.special_events').isBoolean(),
-  check('skills_interests.grant_writing').isBoolean(),
-  check('skills_interests.writing_editing').isBoolean(),
-  check('skills_interests.social_media').isBoolean(),
-  check('skills_interests.fundraising').isBoolean(),
-  check('skills_interests.finance').isBoolean(),
-  check('skills_interests.office_maintenance_housekeeping').isBoolean(),
-  check('skills_interests.international_projects').isBoolean(),
-  check('skills_interests.volunteer_coordination').isBoolean(),
-  check('skills_interests.outreach').isBoolean(),
   check('referral.friend').isBoolean(),
   check('referral.newsletter').isBoolean(),
   check('referral.event').isBoolean(),

--- a/frontend/src/components/AdminDash/Filters.jsx
+++ b/frontend/src/components/AdminDash/Filters.jsx
@@ -37,26 +37,6 @@ const defaultValues = {
       volunteer: false,
       manager: false
     }
-  },
-  skills_interests: {
-    label: 'Skills and Interests',
-    values: {
-      admin_office: false,
-      admin_virtual: false,
-      atlanta_shelter: false,
-      orlando_shelter: false,
-      graphic_web_design: false,
-      special_events: false,
-      grant_writing: false,
-      writing_editing: false,
-      social_media: false,
-      fundraising: false,
-      finance: false,
-      office_maintenance_housekeeping: false,
-      international_projects: false,
-      volunteer_coordination: false,
-      outreach: false
-    }
   }
 };
 


### PR DESCRIPTION
## PR Title/Tagline

This commit removes the fields 'skills and interests' since helping mamas accepts all volunteers. 

### How to Test

1. Please add or build upon a testing card to the [Notion page](http://notion.so) and link it here

### Important Changes

- Fields removed from user model and database
- Fields removed from filter option in applicant viewer
- Fields removed when editing a volunteer's information

### Checklist

- [ ]  Database schema docs have been updated or are not necessary
- [ ]  Code follows design and style guidelines
- [ ]  Code is commented with doc blocks
- [ ]  Tests have been written and executed or are not necessary
- [ ]  Latest code has been rebased from base branch (usually `develop`)
- [ ]  Commits follow guidelines (concise, squashed, etc)
- [ ]  Github issues have been linked in relevant commits
- [ ]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR